### PR TITLE
build: 更新项目依赖版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cn.hamm</groupId>
         <artifactId>airpower</artifactId>
-        <version>2.4.1</version>
+        <version>2.4.2</version>
     </parent>
     <groupId>cn.hamm.spms</groupId>
     <artifactId>server</artifactId>


### PR DESCRIPTION
- 将父项目 airpower 的版本从 2.4.1升级到 2.4.2
- 此更新统一了项目的依赖版本，确保兼容性和最新特性